### PR TITLE
theta: add elliptic_product_isogeny_sqrt

### DIFF
--- a/benches/bench_product_isogeny.rs
+++ b/benches/bench_product_isogeny.rs
@@ -61,7 +61,7 @@ mod benchmark_product {
         let n = 126;
 
         // Compute chain
-        let (E3E4, _, ok) = E1E2.elliptic_product_isogeny(&P1P2, &Q1Q2, n, &[], true);
+        let (E3E4, _, ok) = E1E2.elliptic_product_isogeny_with_torsion(&P1P2, &Q1Q2, n, &[], true);
         assert!(ok == u32::MAX);
 
         let (_, E4) = E3E4.curves();
@@ -70,7 +70,7 @@ mod benchmark_product {
         let bench_id = format!("Benchmarking (2^n, 2^n) isogeny from two, two repo.",);
         c.bench_function(&bench_id, |b| {
             b.iter(|| {
-                black_box(E1E2).elliptic_product_isogeny(
+                black_box(E1E2).elliptic_product_isogeny_with_torsion(
                     &black_box(P1P2),
                     &black_box(Q1Q2),
                     black_box(n),

--- a/benches/bench_scholten.rs
+++ b/benches/bench_scholten.rs
@@ -111,7 +111,7 @@ mod benchmark_scholten {
         let n = 125;
 
         // Compute chain
-        let (F3F4, _, ok) = E1E2.elliptic_product_isogeny(&P1P2, &Q1Q2, n, &[], true);
+        let (F3F4, _, ok) = E1E2.elliptic_product_isogeny_with_torsion(&P1P2, &Q1Q2, n, &[], true);
         assert!(ok == u32::MAX);
 
         let (F3, F4) = F3F4.curves();
@@ -121,7 +121,7 @@ mod benchmark_scholten {
         let bench_id = format!("Benchmarking (2^{n}, 2^{n}) isogeny over Fp2.",);
         c.bench_function(&bench_id, |b| {
             b.iter(|| {
-                black_box(E1E2).elliptic_product_isogeny(
+                black_box(E1E2).elliptic_product_isogeny_with_torsion(
                     &black_box(P1P2),
                     &black_box(Q1Q2),
                     black_box(n),

--- a/src/protocols/sqisign.rs
+++ b/src/protocols/sqisign.rs
@@ -459,7 +459,7 @@ impl<Fq: FqTrait> Sqisign<Fq> {
         // because of linear alegbra choices.
         // If check is zero then an error was detected at some point in the (2, 2) isogeny and the signature
         // is rejected.
-        let (E3E4, _, check) = E1E2.elliptic_product_isogeny(&P1P2, &Q1Q2, e_rsp_prime, &[], true);
+        let (E3E4, _, check) = E1E2.elliptic_product_isogeny_with_torsion(&P1P2, &Q1Q2, e_rsp_prime, &[], true);
         if check == 0 {
             return false;
         }

--- a/src/theta/theta_chain.rs
+++ b/src/theta/theta_chain.rs
@@ -173,4 +173,140 @@ impl<Fq: FqTrait> EllipticProduct<Fq> {
 
         (product, couple_points, ok)
     }
+
+    /// Compute a 2^n isogeny (E1 x E2 -> E3 x E4) using a modified strategy
+    /// that incorporates square root evaluations for the final steps.
+    /// This computes a chain of (2,2)-isogenies where the final torsion
+    /// pushes through 4-torsion and 2-torsion steps directly.
+    /// Returns the codomain and evaluated `ProductPoint`s through the isogeny together
+    /// with a u32 which is `0xFF..FF` on success or `0x00..00` on failure.
+    pub fn elliptic_product_isogeny_sqrt(
+        &self,
+        P1P2: &ProductPoint<Fq>,
+        Q1Q2: &ProductPoint<Fq>,
+        len: usize,
+        image_points: &[ProductPoint<Fq>],
+        verify_chain: bool,
+    ) -> (EllipticProduct<Fq>, Vec<ProductPoint<Fq>>, u32) {
+        // We push the image points through at the same time as the strategy
+        // points, so we need to know how many images we're computing to keep
+        // track of them.
+        let n = image_points.len();
+
+        // Compute the amount of space we need for the strategy.
+        let space = len + 1;
+
+        // Store points of order 2^i for the strategy.
+        let mut product_pts: Vec<ProductPoint<Fq>> = vec![ProductPoint::INFINITY; 2 * space + n];
+        let mut theta_pts: Vec<ThetaPoint<Fq>> = vec![ThetaPoint::default(); 2 * space + n];
+
+        // The values i such that each point in strategy_points has order 2^i
+        let mut orders: Vec<usize> = vec![0; space];
+
+        // Set the first elements of the vector to the points we want to push
+        // through the isogeny.
+        product_pts[..n].copy_from_slice(image_points);
+
+        // Then add the kernel points afterwards.
+        product_pts[n] = *P1P2;
+        product_pts[n + 1] = *Q1Q2;
+
+        // Initialize the orders list. The 4-torsion and 2-torsion steps are handled
+        // separately, so we evaluate up to len - 2.
+        orders[0] = len - 2;
+
+        // Value to determine success / failure of isogeny chain
+        let mut ok = u32::MAX;
+        let mut check: u32;
+
+        // Step One: Perform doubling on the ProductPoints and compute the
+        // codomain from gluing. Keep intermediate doubles to push through.
+        let mut k = 0;
+        k = self.advance_strategy(&mut product_pts, &mut orders, k, n);
+
+        // Compute the Gluing isogeny and push through product_pts into
+        // the vector of ThetaPoints `theta_pts`.
+        let mut domain = self.gluing_isogeny(
+            &product_pts[n + 2 * k],
+            &product_pts[n + 2 * k + 1],
+            &product_pts[..(2 * k + n)],
+            &mut theta_pts,
+        );
+
+        // Reduce the order of the points we evaluated
+        for ord in orders.iter_mut().take(k) {
+            *ord -= 1;
+        }
+
+        let mut stack_ptr = (k as isize) - 1;
+        let mut steps_completed = 1;
+        let total_8_torsion_steps = len - 2;
+
+        // Step Two: Perform standard (2,2) isogenies for the 8-torsion points
+        while stack_ptr >= 0 && orders[stack_ptr as usize] > 0 {
+            let mut k = stack_ptr as usize;
+
+            // Perform doublings of the kernel elements, decreasing the values of orders
+            k = domain.advance_strategy(&mut theta_pts, &mut orders, k, n);
+
+            // Extract out the kernel for this step.
+            let T1 = theta_pts[2 * k + n];
+            let T2 = theta_pts[2 * k + n + 1];
+
+            // For the inner steps we use the standard hadamard configuration
+            let hadamard = [false, true];
+
+            // Determine if we are at the last 8-torsion step to size the evaluation points
+            let is_last_8_torsion = steps_completed + 1 == total_8_torsion_steps;
+            let eval_len = if is_last_8_torsion { n + 2 } else { 2 * k + n };
+
+            // Perform one step of the (2,2) isogeny and push through
+            (domain, check) = ThetaStructure::two_isogeny(
+                &T1,
+                &T2,
+                &mut theta_pts[..eval_len],
+                hadamard,
+                verify_chain,
+            );
+            ok &= check;
+
+            // Reduce the order of the points we evaluated
+            for ord in orders.iter_mut().take(k) {
+                *ord -= 1;
+            }
+
+            stack_ptr = (k as isize) - 1;
+            steps_completed += 1;
+        }
+
+        // Step Three: Evaluate the remaining 4-torsion and 2-torsion steps
+        let T1_prime = theta_pts[n];
+        (domain, check) = domain.two_isogeny_4_torsion(
+            &T1_prime,
+            &mut theta_pts[..n],
+            [false, false],
+            verify_chain,
+        );
+        ok &= check;
+
+        (domain, check) = domain.two_isogeny_2_torsion(
+            &mut theta_pts[..n],
+            [true, false],
+            verify_chain,
+        );
+        ok &= check;
+
+        // Use a symplectic transform to first get the domain into a compatible form
+        // for splitting
+        (domain, check) = domain.splitting_isomorphism(&mut theta_pts);
+        ok &= check;
+
+        // Split from the level 2 theta model to the elliptic product E3 x E4 and map points
+        // onto this product
+        let eval_points = &theta_pts[..n];
+        let mut couple_points = vec![ProductPoint::INFINITY; n];
+        let product = EllipticProduct::split_to_product(&domain, eval_points, &mut couple_points);
+
+        (product, couple_points, ok)
+    }
 }

--- a/src/theta/theta_chain.rs
+++ b/src/theta/theta_chain.rs
@@ -44,12 +44,135 @@ impl<Fq: FqTrait> EllipticProduct<Fq> {
             };
 
             // Double the points m times.
-            // Points are filled in pairs [2^m] P1P2 and  [2^m] Q1Q2
+            // Points are filled in pairs [2^m] P1P2 and [2^m] Q1Q2
             product_pts[n + 2 * k] = self.double_iter(&product_pts[n + 2 * k - 2], m);
             product_pts[n + 2 * k + 1] = self.double_iter(&product_pts[n + 2 * k - 1], m);
             orders[k] = orders[k - 1].saturating_sub(m);
         }
         k
+    }
+
+    /// Computes the first `steps` steps of the 2^n isogeny with kernel
+    /// <(P1, P2), (Q1, Q2)> using a balanced strategy.
+    /// Assumes points Pi, Qi have order 2^(orders_init + 2) to allow for fast
+    /// computation of the codomain for the last two steps without requiring square roots.
+    /// Returns the codomain and evaluated `ProductPoint` through the isogeny
+    /// together with a u32 which is `0xFF..FF` on success or `0x00..00` on failure.
+    #[inline(always)]
+    fn shared_chain(
+        &self,
+        P1P2: &ProductPoint<Fq>,
+        Q1Q2: &ProductPoint<Fq>,
+        orders_init: usize,
+        steps: usize,
+        image_points: &[ProductPoint<Fq>],
+        verify_chain: bool,
+    ) -> (ThetaStructure<Fq>, Vec<ThetaPoint<Fq>>, u32) {
+        let n = image_points.len();
+
+        // Compute the amount of space we need for the balanced strategy.
+        let space = (usize::BITS - orders_init.leading_zeros() + 1) as usize;
+
+        // Store points of order 2^i for the balanced strategy. We need two
+        // vectors here, as the first step computes with elements of type
+        // ProductPoint, while every other step computes points of type
+        // ThetaPoint.
+        let mut product_pts: Vec<ProductPoint<Fq>> = vec![ProductPoint::INFINITY; 2 * space + n];
+        let mut theta_pts: Vec<ThetaPoint<Fq>> = vec![ThetaPoint::default(); 2 * space + n];
+
+        // The values i such that each point in strategy_points has order 2^i
+        let mut orders: Vec<usize> = vec![0; space];
+
+        // Set the first elements of the vector to the points we want to push
+        // through the isogeny.
+        product_pts[..n].copy_from_slice(image_points);
+
+        // Then add the kernel points afterwards.
+        product_pts[n] = *P1P2;
+        product_pts[n + 1] = *Q1Q2;
+
+        // Initalise the orders list, points in the above vectors have order
+        // 2^(orders_init + 2), as we use the 8-torsion above.
+        orders[0] = orders_init;
+
+        // Value to determine success / failure of isogeny chain
+        let mut ok = u32::MAX;
+        let mut k = 0;
+
+        // Step One: Perform doubling on the ProductPoints and compute the
+        // codomain from gluing. Keep intermediate doubles to push through
+        // the isogeny to save on doublings later.
+        k = self.advance_strategy(&mut product_pts, &mut orders, k, n);
+
+        // Compute the Gluing isogeny and push through product_strategy_pts through
+        // into the vector of ThetaPoints `strategy_pts`.
+        let mut domain = self.gluing_isogeny(
+            &product_pts[n + 2 * k],
+            &product_pts[n + 2 * k + 1],
+            &product_pts[..(2 * k + n)],
+            &mut theta_pts,
+        );
+
+        // Reduce the order of the points we evaluated
+        for ord in orders.iter_mut().take(k) {
+            *ord -= 1;
+        }
+        k = k.saturating_sub(1);
+
+        // Step Two: Perform doubling on the ThetaPoints and compute the
+        // codomain ThetaStructure.
+        for _ in 1..steps {
+            // Perform doublings of the kernel elements, decreasing the values of orders
+            k = domain.advance_strategy(&mut theta_pts, &mut orders, k, n);
+
+            // Extract out the kernel for this step.
+            let T1 = theta_pts[2 * k + n];
+            let T2 = theta_pts[2 * k + n + 1];
+
+            let check;
+
+            // Inner 8-torsion steps always use the standard [false, true] hadamard configuration.
+            // Perform one step of the (2,2) isogeny and push through all points.
+            (domain, check) = ThetaStructure::two_isogeny(
+                &T1,
+                &T2,
+                &mut theta_pts[..(2 * k + n)],
+                [false, true],
+                verify_chain,
+            );
+            ok &= check;
+
+            // Reduce the order of the points we evaluated
+            for ord in orders.iter_mut().take(k) {
+                *ord -= 1;
+            }
+            k = k.saturating_sub(1);
+        }
+
+        (domain, theta_pts, ok)
+    }
+
+    #[inline(always)]
+    fn finalize_isogeny(
+        mut domain: ThetaStructure<Fq>,
+        mut theta_pts: Vec<ThetaPoint<Fq>>,
+        n: usize,
+        mut ok: u32,
+    ) -> (EllipticProduct<Fq>, Vec<ProductPoint<Fq>>, u32) {
+        let check;
+
+        // Use a symplectic transform to first get the domain into a compatible form
+        // for splitting
+        (domain, check) = domain.splitting_isomorphism(&mut theta_pts);
+        ok &= check;
+
+        // Split from the level 2 theta model to the elliptic product E3 x E4 and map points
+        // onto this product
+        let eval_points = &theta_pts[..n];
+        let mut couple_points = vec![ProductPoint::INFINITY; n];
+        let product = EllipticProduct::split_to_product(&domain, eval_points, &mut couple_points);
+
+        (product, couple_points, ok)
     }
 
     /// Compute an 2^n isogeny (E1 x E2 -> E3 x E4) with kernel <(P1, P2), (Q1, Q2)>
@@ -71,113 +194,52 @@ impl<Fq: FqTrait> EllipticProduct<Fq> {
         // track of them.
         let n = image_points.len();
 
-        // Compute the amount of space we need for the balanced strategy.
-        let space = (usize::BITS - len.leading_zeros() + 1) as usize;
-
-        // Store points of order 2^i for the balanced strategy. We need two
-        // vectors here, as the first step computes with elements of type
-        // ProductPoint, while every other step computes points of type
-        // ThetaPoint.
-        let mut product_pts: Vec<ProductPoint<Fq>> = vec![ProductPoint::INFINITY; 2 * space + n];
-        let mut theta_pts: Vec<ThetaPoint<Fq>> = vec![ThetaPoint::default(); 2 * space + n];
-
-        // The values i such that each point in stategy_points has order 2^i
-        let mut orders: Vec<usize> = vec![0; space];
-
-        // Set the first elements of the vector to the points we want to push
-        // through the isogeny.
-        product_pts[..n].copy_from_slice(image_points);
-
-        // Then add the kernel points afterwards.
-        product_pts[n] = *P1P2;
-        product_pts[n + 1] = *Q1Q2;
-
-        // Initalise the orders list, points in the above vectors have order
-        // 2^(orders[i] + 2), as we use the 8-torsion above.
-        orders[0] = len;
-
-        // Value to determine success / failure of isogeny chain
-        let mut ok = u32::MAX;
-        let mut check: u32;
-
-        // Step One: Perform doubling on the ProductPoints and compute the
-        // codomain from gluing. Keep intermediate doubles to push through
-        // the isogeny to save on doublings later.
-        let mut k = 0;
-        k = self.advance_strategy(&mut product_pts, &mut orders, k, n);
-
-        // Compute the Gluing isogeny and push through product_strategy_pts through
-        // into the vector of ThetaPoints `strategy_pts`.
-        let mut domain = self.gluing_isogeny(
-            &product_pts[n + 2 * k],
-            &product_pts[n + 2 * k + 1],
-            &product_pts[..(2 * k + n)],
-            &mut theta_pts,
+        // Step 1..len-1
+        let (mut domain, mut theta_pts, mut ok) = self.shared_chain(
+            P1P2,
+            Q1Q2,
+            len,
+            len - 2,
+            image_points,
+            verify_chain
         );
 
-        // Reduce the order of the points we evaluated
-        for ord in orders.iter_mut().take(k) {
-            *ord -= 1;
-        }
-        k -= 1;
+        // Step len - 1
+        let T1_ord4 = theta_pts[n];
+        let T2_ord4 = theta_pts[n + 1];
+        let T1_ord2 = domain.double_iter(&T1_ord4, 1);
+        let T2_ord2 = domain.double_iter(&T2_ord4, 1);
 
-        // Step Two: Perform doubling on the ThetaPoints and compute the
-        // codomain ThetaStructure.
-        for i in 1..len {
-            // Perform doublings of the kernel elements, decreasing the values of orders
-            k = domain.advance_strategy(&mut theta_pts, &mut orders, k, n);
-
-            // Extract out the kernel for this step.
-            let T1 = theta_pts[2 * k + n];
-            let T2 = theta_pts[2 * k + n + 1];
-
-            // For the last two steps, we need to be careful because of the zero-null
-            // coordinates appearing from the product structure. To avoid these, we
-            // use the hadamard transform to avoid them,
-            let steps_remaining = len - i;
-            let hadamard = [steps_remaining == 1, steps_remaining > 2];
-
-            // The verify check looks for when we're next to a product. We know this
-            // happens at the end of the chain, so we never perform this verification
-            // here. Instead, verification of the final (2,2) step is performed in
-            // splitting.
-            let verify = verify_chain && steps_remaining != 1;
-
-            // Perform one step of the (2,2) isogeny and push through all points.
-            (domain, check) = ThetaStructure::two_isogeny(
-                &T1,
-                &T2,
-                &mut theta_pts[..(2 * k + n)],
-                hadamard,
-                verify,
-            );
-            ok &= check;
-
-            // Reduce the order of the points we evaluated
-            for ord in orders.iter_mut().take(k) {
-                *ord -= 1;
-            }
-            k = k.saturating_sub(1);
-        }
-
-        // Use a symplectic transform to first get the domain into a compatible form
-        // for splitting
-        (domain, check) = domain.splitting_isomorphism(&mut theta_pts);
+        let mut check;
+        (_, check) = ThetaStructure::two_isogeny(
+            &T1_ord2,
+            &T2_ord2,
+            &mut theta_pts[..n + 2],
+            [false, false],
+            verify_chain,
+        );
         ok &= check;
 
-        // Split from the level 2 theta model to the elliptic product E3 x E4 and map points
-        // onto this product
-        let eval_points = &theta_pts[..n];
-        let mut couple_points = vec![ProductPoint::INFINITY; n];
-        let product = EllipticProduct::split_to_product(&domain, eval_points, &mut couple_points);
+        // Step len
+        let T1_final = theta_pts[n];
+        let T2_final = theta_pts[n + 1];
 
-        (product, couple_points, ok)
+        (domain, check) = ThetaStructure::two_isogeny(
+            &T1_final,
+            &T2_final,
+            &mut theta_pts[..n],
+            [true, false],
+            false,
+        );
+        ok &= check;
+
+        Self::finalize_isogeny(domain, theta_pts, n, ok)
     }
 
-    /// Compute a 2^n isogeny (E1 x E2 -> E3 x E4) using a modified strategy
-    /// that incorporates square root evaluations for the final steps.
-    /// This computes a chain of (2,2)-isogenies where the final torsion
-    /// pushes through 4-torsion and 2-torsion steps directly.
+    /// Compute a 2^n isogeny (E1 x E2 -> E3 x E4) without points of 2^{n+2}
+    /// torsion.
+    /// Assumes kernel <(P1, P2), (Q1, Q2)> have points of order 2^n.
+    /// This incorporates square root evaluations for the final steps.
     /// Returns the codomain and evaluated `ProductPoint`s through the isogeny together
     /// with a u32 which is `0xFF..FF` on success or `0x00..00` on failure.
     pub fn elliptic_product_isogeny_sqrt(
@@ -192,95 +254,35 @@ impl<Fq: FqTrait> EllipticProduct<Fq> {
         // points, so we need to know how many images we're computing to keep
         // track of them.
         let n = image_points.len();
-
-        // Compute the amount of space we need for the strategy.
-        let space = len + 1;
-
-        // Store points of order 2^i for the strategy.
-        let mut product_pts: Vec<ProductPoint<Fq>> = vec![ProductPoint::INFINITY; 2 * space + n];
-        let mut theta_pts: Vec<ThetaPoint<Fq>> = vec![ThetaPoint::default(); 2 * space + n];
-
-        // The values i such that each point in strategy_points has order 2^i
-        let mut orders: Vec<usize> = vec![0; space];
-
-        // Set the first elements of the vector to the points we want to push
-        // through the isogeny.
-        product_pts[..n].copy_from_slice(image_points);
-
-        // Then add the kernel points afterwards.
-        product_pts[n] = *P1P2;
-        product_pts[n + 1] = *Q1Q2;
-
-        // Initialize the orders list. The 4-torsion and 2-torsion steps are handled
-        // separately, so we evaluate up to len - 2.
-        orders[0] = len - 2;
-
-        // Value to determine success / failure of isogeny chain
-        let mut ok = u32::MAX;
-        let mut check: u32;
-
-        // Step One: Perform doubling on the ProductPoints and compute the
-        // codomain from gluing. Keep intermediate doubles to push through.
-        let mut k = 0;
-        k = self.advance_strategy(&mut product_pts, &mut orders, k, n);
-
-        // Compute the Gluing isogeny and push through product_pts into
-        // the vector of ThetaPoints `theta_pts`.
-        let mut domain = self.gluing_isogeny(
-            &product_pts[n + 2 * k],
-            &product_pts[n + 2 * k + 1],
-            &product_pts[..(2 * k + n)],
-            &mut theta_pts,
+        let mut domain;
+        let (_, mut theta_pts, mut ok) = self.shared_chain(
+            P1P2,
+            Q1Q2,
+            len - 2,
+            len - 3,
+            image_points,
+            verify_chain
         );
 
-        // Reduce the order of the points we evaluated
-        for ord in orders.iter_mut().take(k) {
-            *ord -= 1;
-        }
+        // Evaluate the final 8-torsion step by hand where k=0.
+        // Ensure we evaluate n+2 points to keep P1P2 and Q1Q2 mapped through
+        // the isogenies.
+        let T1_last_8 = theta_pts[n];
+        let T2_last_8 = theta_pts[n + 1];
+        let mut check;
 
-        let mut stack_ptr = (k as isize) - 1;
-        let mut steps_completed = 1;
-        let total_8_torsion_steps = len - 2;
+        (domain, check) = ThetaStructure::two_isogeny(
+            &T1_last_8,
+            &T2_last_8,
+            &mut theta_pts[..n + 2],
+            [false, true],
+            verify_chain,
+        );
+        ok &= check;
 
-        // Step Two: Perform standard (2,2) isogenies for the 8-torsion points
-        while stack_ptr >= 0 && orders[stack_ptr as usize] > 0 {
-            let mut k = stack_ptr as usize;
-
-            // Perform doublings of the kernel elements, decreasing the values of orders
-            k = domain.advance_strategy(&mut theta_pts, &mut orders, k, n);
-
-            // Extract out the kernel for this step.
-            let T1 = theta_pts[2 * k + n];
-            let T2 = theta_pts[2 * k + n + 1];
-
-            // For the inner steps we use the standard hadamard configuration
-            let hadamard = [false, true];
-
-            // Determine if we are at the last 8-torsion step to size the evaluation points
-            let is_last_8_torsion = steps_completed + 1 == total_8_torsion_steps;
-            let eval_len = if is_last_8_torsion { n + 2 } else { 2 * k + n };
-
-            // Perform one step of the (2,2) isogeny and push through
-            (domain, check) = ThetaStructure::two_isogeny(
-                &T1,
-                &T2,
-                &mut theta_pts[..eval_len],
-                hadamard,
-                verify_chain,
-            );
-            ok &= check;
-
-            // Reduce the order of the points we evaluated
-            for ord in orders.iter_mut().take(k) {
-                *ord -= 1;
-            }
-
-            stack_ptr = (k as isize) - 1;
-            steps_completed += 1;
-        }
-
-        // Step Three: Evaluate the remaining 4-torsion and 2-torsion steps
+        // Step len-1: Knowing only points of 4-torsion.
         let T1_prime = theta_pts[n];
+
         (domain, check) = domain.two_isogeny_4_torsion(
             &T1_prime,
             &mut theta_pts[..n],
@@ -289,6 +291,7 @@ impl<Fq: FqTrait> EllipticProduct<Fq> {
         );
         ok &= check;
 
+        // Step len: Knowing only points of 2-torsion.
         (domain, check) = domain.two_isogeny_2_torsion(
             &mut theta_pts[..n],
             [true, false],
@@ -296,17 +299,6 @@ impl<Fq: FqTrait> EllipticProduct<Fq> {
         );
         ok &= check;
 
-        // Use a symplectic transform to first get the domain into a compatible form
-        // for splitting
-        (domain, check) = domain.splitting_isomorphism(&mut theta_pts);
-        ok &= check;
-
-        // Split from the level 2 theta model to the elliptic product E3 x E4 and map points
-        // onto this product
-        let eval_points = &theta_pts[..n];
-        let mut couple_points = vec![ProductPoint::INFINITY; n];
-        let product = EllipticProduct::split_to_product(&domain, eval_points, &mut couple_points);
-
-        (product, couple_points, ok)
+        Self::finalize_isogeny(domain, theta_pts, n, ok)
     }
 }

--- a/src/theta/theta_chain.rs
+++ b/src/theta/theta_chain.rs
@@ -181,7 +181,7 @@ impl<Fq: FqTrait> EllipticProduct<Fq> {
     /// the codomain for the last two steps without requiring square roots.
     /// Returns the codomain and evaluated `ProductPoint` through the isogeny together
     /// with a u32 which is `0xFF..FF` on success or `0x00..00` on failure.
-    pub fn elliptic_product_isogeny(
+    pub fn elliptic_product_isogeny_with_torsion(
         &self,
         P1P2: &ProductPoint<Fq>,
         Q1Q2: &ProductPoint<Fq>,
@@ -242,7 +242,7 @@ impl<Fq: FqTrait> EllipticProduct<Fq> {
     /// This incorporates square root evaluations for the final steps.
     /// Returns the codomain and evaluated `ProductPoint`s through the isogeny together
     /// with a u32 which is `0xFF..FF` on success or `0x00..00` on failure.
-    pub fn elliptic_product_isogeny_sqrt(
+    pub fn elliptic_product_isogeny(
         &self,
         P1P2: &ProductPoint<Fq>,
         Q1Q2: &ProductPoint<Fq>,

--- a/src/theta/theta_isogeny.rs
+++ b/src/theta/theta_isogeny.rs
@@ -89,4 +89,138 @@ impl<Fq: FqTrait> ThetaStructure<Fq> {
 
         (codomain, ok)
     }
+
+    /// Given the 4-torsion above the kernel, compute the codomain of the
+    /// (2,2)-isogeny and the image of all points in `image_points`.
+    /// Cost:
+    ///   Codomain: 8S + 17M + 2Sqrt
+    pub fn two_isogeny_4_torsion(
+        &self,
+        T1_prime: &ThetaPoint<Fq>,
+        image_points: &mut [ThetaPoint<Fq>],
+        hadamard: [bool; 2],
+        verify_codomain: bool,
+    ) -> (Self, u32) {
+        let mut ok = u32::MAX;
+
+        // Extract squared coordinates
+        let (xAB, _, xCD, _) = T1_prime.cond_hadamard_square_hadamard(hadamard[0]);
+        let (A2, B2, C2, D2) = self.null_point().cond_hadamard_square_hadamard(hadamard[0]);
+
+        // Compute square roots required for the 4-torsion codomain structure
+        let (AB, r1) = (A2 * B2).sqrt();
+        let (AC, r2) = (A2 * C2).sqrt();
+
+        ok &= r1 & r2;
+
+        // Compute codomain coordinates
+        let mut B = AB * AC;
+        let mut D_inv = B * xCD;
+        B *= xAB;
+
+        let D = xCD * AB * A2;
+
+        let mut A = xAB * A2;
+        let C = A * C2;
+        A *= AC;
+
+        // Compute coordinate inverses for mapping image points
+        let mut A_inv = xAB * D2;
+        let mut C_inv = A_inv * B2;
+        A_inv *= C2;
+        let B_inv = A_inv * AB;
+        A_inv *= B2;
+        C_inv *= AC;
+        D_inv *= B2;
+
+        let mut codomain_A = A;
+        let mut codomain_B = B;
+        let mut codomain_C = C;
+        let mut codomain_D = D;
+
+        if hadamard[1] {
+            (codomain_A, codomain_B, codomain_C, codomain_D) = to_hadamard(&codomain_A, &codomain_B, &codomain_C, &codomain_D);
+        }
+
+        if verify_codomain {
+            ok &= !codomain_A.is_zero();
+        }
+
+        let codomain = Self::new_from_coords(&codomain_A, &codomain_B, &codomain_C, &codomain_D);
+
+        // Push image points through the isogeny
+        for P in image_points.iter_mut() {
+            let (mut XX, mut YY, mut ZZ, mut TT) = P.cond_hadamard_square_hadamard(hadamard[0]);
+            XX *= A_inv;
+            YY *= B_inv;
+            ZZ *= C_inv;
+            TT *= D_inv;
+            if hadamard[1] {
+                (XX, YY, ZZ, TT) = to_hadamard(&XX, &YY, &ZZ, &TT);
+            }
+            *P = ThetaPoint::new(&XX, &YY, &ZZ, &TT);
+        }
+
+        (codomain, ok)
+    }
+
+    /// Computes a (2,2)-isogeny from a level 2 theta structure using a
+    /// 2-torsion kernel point (the null point).
+    /// Cost:
+    ///   Codomain: 4S + 10M + 3Sqrt
+    pub fn two_isogeny_2_torsion(
+        &self,
+        image_points: &mut [ThetaPoint<Fq>],
+        hadamard: [bool; 2],
+        verify_codomain: bool,
+    ) -> (Self, u32) {
+        let mut ok = u32::MAX;
+
+        // Extract squared coordinates of the null point
+        let (A2, B2, C2, D2) = self.null_point().cond_hadamard_square_hadamard(hadamard[0]);
+
+        // Compute square roots required for the 2-torsion codomain structure
+        let (val_B, r1) = (A2 * B2).sqrt();
+        let (val_C, r2) = (A2 * C2).sqrt();
+        let (val_D, r3) = (A2 * D2).sqrt();
+
+        ok &= r1 & r2 & r3;
+
+        // Compute coordinate inverses for mapping image points
+        let mut A_inv = C2 * D2;
+        let B_inv = A_inv * val_B;
+        A_inv *= B2;
+        let C_inv = D2 * B2 * val_C;
+        let D_inv = C2 * B2 * val_D;
+
+        let mut codomain_A = A2;
+        let mut codomain_B = val_B;
+        let mut codomain_C = val_C;
+        let mut codomain_D = val_D;
+
+        if hadamard[1] {
+            (codomain_A, codomain_B, codomain_C, codomain_D) = to_hadamard(&codomain_A, &codomain_B, &codomain_C, &codomain_D);
+        }
+
+        if verify_codomain {
+            ok &= !codomain_A.is_zero();
+        }
+
+        let codomain = Self::new_from_coords(&codomain_A, &codomain_B, &codomain_C, &codomain_D);
+
+        // Push image points through the isogeny
+        for P in image_points.iter_mut() {
+            let (mut XX, mut YY, mut ZZ, mut TT) = P.cond_hadamard_square_hadamard(hadamard[0]);
+            XX *= A_inv;
+            YY *= B_inv;
+            ZZ *= C_inv;
+            TT *= D_inv;
+            if hadamard[1] {
+                (XX, YY, ZZ, TT) = to_hadamard(&XX, &YY, &ZZ, &TT);
+            }
+            *P = ThetaPoint::new(&XX, &YY, &ZZ, &TT);
+        }
+
+        (codomain, ok)
+    }
 }

--- a/tests/test_product_isogeny.rs
+++ b/tests/test_product_isogeny.rs
@@ -41,7 +41,7 @@ mod test_product_isogeny {
     static PB_Y_IM_STR: &str = "12a4e94423744ae02c830a5188e345b9eac47823cfd7a70062995a0517137a028863d606013f8d4c42018cd7b540ad5b8a7135bbbfa3caf94019832346732010";
 
     #[test]
-    fn test_elliptic_product_isogeny() {
+    fn test_elliptic_product_isogeny_with_torsion() {
         let A1 = Fp2::ZERO;
         let (A2, _) = Fp2::decode(&hex::decode(A2_STR).unwrap());
 
@@ -90,7 +90,7 @@ mod test_product_isogeny {
 
         // Compute chain
         let (E3E4, images, ok) =
-            E1E2.elliptic_product_isogeny(&P1P2, &Q1Q2, n, &image_points, true);
+            E1E2.elliptic_product_isogeny_with_torsion(&P1P2, &Q1Q2, n, &image_points, true);
         assert!(ok == u32::MAX);
 
         let (_, E4) = E3E4.curves();
@@ -105,7 +105,7 @@ mod test_product_isogeny {
     }
 
     #[test]
-    fn test_elliptic_product_isogeny_sqrt() {
+    fn test_elliptic_product_isogeny() {
         let A1 = Fp2::ZERO;
         let (A2, _) = Fp2::decode(&hex::decode(A2_STR).unwrap());
         let (P1_X, _) = Fp2::decode(&hex::decode(P1_X_STR).unwrap());
@@ -137,8 +137,8 @@ mod test_product_isogeny {
 
         let n = 126;
 
-        // Compute the original chain using elliptic_product_isogeny
-        let (E3E4_orig, _, ok_orig) = E1E2.elliptic_product_isogeny(
+        // Compute the original chain using elliptic_product_isogeny_with_torsion
+        let (E3E4_orig, _, ok_orig) = E1E2.elliptic_product_isogeny_with_torsion(
             &P1P2,
             &Q1Q2,
             n,
@@ -151,7 +151,7 @@ mod test_product_isogeny {
         let Q1Q2_strict = E1E2.double_iter(&Q1Q2, 2);
 
         // Compute the chain without 8-torsion
-        let (E3E4_strict, _, ok_strict) = E1E2.elliptic_product_isogeny_sqrt(
+        let (E3E4_strict, _, ok_strict) = E1E2.elliptic_product_isogeny(
             &P1P2_strict,
             &Q1Q2_strict,
             n,
@@ -159,10 +159,10 @@ mod test_product_isogeny {
             false,
         );
 
-        assert_eq!(ok_orig, u32::MAX, "original elliptic_product_isogeny failed");
-        assert_eq!(ok_strict, u32::MAX, "elliptic_product_isogeny_sqrt failed");
+        assert_eq!(ok_orig, u32::MAX, "original elliptic_product_isogeny_with_torsion failed");
+        assert_eq!(ok_strict, u32::MAX, "elliptic_product_isogeny failed");
 
-        // Compare J-Invariants of codomain against elliptic_product_isogeny
+        // Compare J-Invariants of codomain against elliptic_product_isogeny_with_torsion
         let (E3_orig, E4_orig) = E3E4_orig.curves();
         let (E3_strict, E4_strict) = E3E4_strict.curves();
 
@@ -177,7 +177,7 @@ mod test_product_isogeny {
         assert_eq!(
             strict_matches_orig,
             u32::MAX,
-            "codomain mismatch between elliptic_product_isogeny and elliptic_product_isogeny_sqrt"
+            "codomain mismatch between elliptic_product_isogeny_with_torsion and elliptic_product_isogeny"
         );
     }
 }
@@ -231,7 +231,7 @@ mod test_product_isogeny_castryck_decru {
     }
 
     #[test]
-    fn test_elliptic_product_isogeny_sqrt_point_eval() {
+    fn test_elliptic_product_isogeny_point_eval() {
         let E0 = Curve::<Fp2> {
             A: Fp2::ZERO,
             A24: Fp2::new(&Fp::new([0, 0, 0, 9223372036854775808]), &Fp::ZERO),
@@ -337,7 +337,7 @@ mod test_product_isogeny_castryck_decru {
         ];
 
         // Evaluate chain with sqrt strategy
-        let (e_out, images, ok) = eb_e0.elliptic_product_isogeny_sqrt(&k1, &k2, 117, &eval_pts, false);
+        let (e_out, images, ok) = eb_e0.elliptic_product_isogeny(&k1, &k2, 117, &eval_pts, false);
         assert_eq!(ok, u32::MAX, "Isogeny chain evaluation failed");
 
         let (e3, e4) = e_out.curves();

--- a/tests/test_product_isogeny.rs
+++ b/tests/test_product_isogeny.rs
@@ -103,4 +103,99 @@ mod test_product_isogeny {
         assert!(P1_check);
         assert!(P2_check);
     }
+
+    fn j_invariant(A: &Fp2) -> Fp2 {
+        let one = Fp2::ONE;
+        let two = one + one;
+        let three = two + one;
+        let four = three + one;
+
+        let mut c256 = one;
+        for _ in 0..8 { c256 = c256 + c256; }
+
+        let A2 = A.square();
+        let mut num = A2 - three;
+        num = num.square() * num;
+        num *= c256;
+
+        let den = A2 - four;
+        num * den.invert()
+    }
+
+    #[test]
+    fn test_elliptic_product_isogeny_sqrt() {
+        let A1 = Fp2::ZERO;
+        let (A2, _) = Fp2::decode(&hex::decode(A2_STR).unwrap());
+        let (P1_X, _) = Fp2::decode(&hex::decode(P1_X_STR).unwrap());
+        let (P1_Y, _) = Fp2::decode(&hex::decode(P1_Y_STR).unwrap());
+        let (P2_X, _) = Fp2::decode(&hex::decode(P2_X_STR).unwrap());
+        let (P2_Y, _) = Fp2::decode(&hex::decode(P2_Y_STR).unwrap());
+        let (Q1_X, _) = Fp2::decode(&hex::decode(Q1_X_STR).unwrap());
+        let (Q1_Y, _) = Fp2::decode(&hex::decode(Q1_Y_STR).unwrap());
+        let (Q2_X, _) = Fp2::decode(&hex::decode(Q2_X_STR).unwrap());
+        let (Q2_Y, _) = Fp2::decode(&hex::decode(Q2_Y_STR).unwrap());
+        let (PA_X, _) = Fp2::decode(&hex::decode(PA_X_STR).unwrap());
+        let (PA_Y, _) = Fp2::decode(&hex::decode(PA_Y_STR).unwrap());
+
+        let E1 = Curve::new(&A1);
+        let E2 = Curve::new(&A2);
+        let E1E2 = EllipticProduct::new(&E1, &E2);
+
+        let P1 = Point::new_xy(&P1_X, &P1_Y);
+        let P2 = Point::new_xy(&P2_X, &P2_Y);
+        let Q1 = Point::new_xy(&Q1_X, &Q1_Y);
+        let Q2 = Point::new_xy(&Q2_X, &Q2_Y);
+        let P1P2 = ProductPoint::new(&P1, &P2);
+        let Q1Q2 = ProductPoint::new(&Q1, &Q2);
+
+        let PA = Point::INFINITY;
+        let PB = Point::new_xy(&PA_X, &PA_Y);
+        let PAPB = ProductPoint::new(&PA, &PB);
+        let image_points = [PAPB];
+
+        let n = 126;
+
+        // Compute the original chain using elliptic_product_isogeny
+        let (E3E4_orig, _, ok_orig) = E1E2.elliptic_product_isogeny(
+            &P1P2,
+            &Q1Q2,
+            n,
+            &image_points,
+            false,
+        );
+
+        // Adjust the kernel by doubling twice to drop the 8-torsion padding
+        let P1P2_strict = E1E2.double_iter(&P1P2, 2);
+        let Q1Q2_strict = E1E2.double_iter(&Q1Q2, 2);
+
+        // Compute the chain without 8-torsion
+        let (E3E4_strict, _, ok_strict) = E1E2.elliptic_product_isogeny_sqrt(
+            &P1P2_strict,
+            &Q1Q2_strict,
+            n,
+            &image_points,
+            false,
+        );
+
+        assert_eq!(ok_orig, u32::MAX, "original elliptic_product_isogeny failed");
+        assert_eq!(ok_strict, u32::MAX, "elliptic_product_isogeny_sqrt failed");
+
+        // Compare J-Invariants of codomain against elliptic_product_isogeny
+        let (E3_orig, E4_orig) = E3E4_orig.curves();
+        let (E3_strict, E4_strict) = E3E4_strict.curves();
+
+        let j_E3_orig = j_invariant(&E3_orig.A);
+        let j_E4_orig = j_invariant(&E4_orig.A);
+        let j_E3_strict = j_invariant(&E3_strict.A);
+        let j_E4_strict = j_invariant(&E4_strict.A);
+
+        let strict_matches_orig = (j_E3_orig.equals(&j_E3_strict) & j_E4_orig.equals(&j_E4_strict)) |
+                                  (j_E3_orig.equals(&j_E4_strict) & j_E4_orig.equals(&j_E3_strict));
+
+        assert_eq!(
+            strict_matches_orig,
+            u32::MAX,
+            "codomain mismatch between elliptic_product_isogeny and elliptic_product_isogeny_sqrt"
+        );
+    }
 }

--- a/tests/test_product_isogeny.rs
+++ b/tests/test_product_isogeny.rs
@@ -104,24 +104,6 @@ mod test_product_isogeny {
         assert!(P2_check);
     }
 
-    fn j_invariant(A: &Fp2) -> Fp2 {
-        let one = Fp2::ONE;
-        let two = one + one;
-        let three = two + one;
-        let four = three + one;
-
-        let mut c256 = one;
-        for _ in 0..8 { c256 = c256 + c256; }
-
-        let A2 = A.square();
-        let mut num = A2 - three;
-        num = num.square() * num;
-        num *= c256;
-
-        let den = A2 - four;
-        num * den.invert()
-    }
-
     #[test]
     fn test_elliptic_product_isogeny_sqrt() {
         let A1 = Fp2::ZERO;
@@ -184,10 +166,10 @@ mod test_product_isogeny {
         let (E3_orig, E4_orig) = E3E4_orig.curves();
         let (E3_strict, E4_strict) = E3E4_strict.curves();
 
-        let j_E3_orig = j_invariant(&E3_orig.A);
-        let j_E4_orig = j_invariant(&E4_orig.A);
-        let j_E3_strict = j_invariant(&E3_strict.A);
-        let j_E4_strict = j_invariant(&E4_strict.A);
+        let j_E3_orig = &E3_orig.j_invariant();
+        let j_E4_orig = &E4_orig.j_invariant();
+        let j_E3_strict = &E3_strict.j_invariant();
+        let j_E4_strict = &E4_strict.j_invariant();
 
         let strict_matches_orig = (j_E3_orig.equals(&j_E3_strict) & j_E4_orig.equals(&j_E4_strict)) |
                                   (j_E3_orig.equals(&j_E4_strict) & j_E4_orig.equals(&j_E3_strict));

--- a/tests/test_product_isogeny.rs
+++ b/tests/test_product_isogeny.rs
@@ -181,3 +181,207 @@ mod test_product_isogeny {
         );
     }
 }
+
+#[cfg(test)]
+mod test_product_isogeny_castryck_decru {
+    use isogeny::{
+        elliptic::{curve::Curve, projective_point::Point},
+        theta::elliptic_product::{EllipticProduct, ProductPoint},
+    };
+
+    // The Castryck-Decru instance uses a specific modulus
+    static MODULUS: [u64; 4] = [
+        0xffffffffffffffff,
+        0xdcdfffffffffffff,
+        0xa0e11417aba2a421,
+        0x00004937aae3413f,
+    ];
+    fp2::define_fp2_from_modulus!(typename = Fp2, base_typename = Fp, modulus = MODULUS,);
+
+    const A: u64 = 90503613537036670;
+    const B: u64 = 300628336613559557;
+
+    fn iota(p: &Point<Fp2>) -> Point<Fp2> {
+        let mut res = *p;
+        res.X = -res.X;
+        res.Y *= Fp2::ZETA;
+        res
+    }
+
+    fn psi_action(curve: &Curve<Fp2>, p: &Point<Fp2>) -> Point<Fp2> {
+        let a_bytes = A.to_le_bytes();
+        let b_bytes = B.to_le_bytes();
+        let a_p = curve.mul(p, &a_bytes, 64);
+        let b_p = curve.mul(p, &b_bytes, 64);
+        let iota_b_p = iota(&b_p);
+        curve.add(&a_p, &iota_b_p)
+    }
+
+    fn decode_fp2(x0_hex: &str, x1_hex: &str) -> Fp2 {
+        let (x0, _) = Fp::decode(&hex::decode(x0_hex).unwrap());
+        let (x1, _) = Fp::decode(&hex::decode(x1_hex).unwrap());
+        Fp2::new(&x0, &x1)
+    }
+
+    fn decode_fp2_flat(h: &str) -> Fp2 {
+        let bytes = hex::decode(h).unwrap();
+        let (x0, _) = Fp::decode(&bytes[..30]);
+        let (x1, _) = Fp::decode(&bytes[30..]);
+        Fp2::new(&x0, &x1)
+    }
+
+    #[test]
+    fn test_elliptic_product_isogeny_sqrt_point_eval() {
+        let E0 = Curve::<Fp2> {
+            A: Fp2::ZERO,
+            A24: Fp2::new(&Fp::new([0, 0, 0, 9223372036854775808]), &Fp::ZERO),
+        };
+
+        let EB = Curve::<Fp2> {
+            A: decode_fp2(
+                "5a32b8fee4cb360d1934edd47b54a665e2ff853724d2c6e0467eb01dae0f",
+                "633d6ec480a858b3ffb3c09d369fa82f5b79a343bbf7ab0d8a726a841e46"
+            ),
+            A24: decode_fp2(
+                "970cae3ff9b24d43064d3bf51e956999f87fe10d89b431b8911f6c87eb03",
+                "588f1b31202ad6ecff2c70a7cd27923170d9a29100cd133c920d45617148"
+            ),
+        };
+
+        let P2 = Point::<Fp2> {
+            X: decode_fp2(
+                "5e5c6e8e8aafe8a017472bf00902dd634a405014ea027ad57bc011182106",
+                "7566814d948e0f527f8229300052560cc06d3dae298d32096c921e790806"
+            ),
+            Y: decode_fp2(
+                "0d81d61a4a834a5c9edba4de8cf64a2975efd16db778cdffce2aaa375a27",
+                "5d463d3eab5e0f81bde9aace44c5224ea5ab5da6a46284ebd2348f5e7c0f"
+            ),
+            Z: Fp2::ONE,
+        };
+
+        let Q2 = Point::<Fp2> {
+            X: decode_fp2(
+                "bf32e2f5f90e97a5f98b418836961d92ffd4223fe630af5d1230c0270a32",
+                "5d2aa79a442cce1ec1fc913f00112a1395a9f4dd8afefb0decae0446f91d"
+            ),
+            Y: decode_fp2(
+                "3eab3190e868a399ffcfc51303fdf0ef162b077f114e39df05505511c70b",
+                "c9404ff59d64dfbc0ea045d05a04b9bede3abd81de29764ccad0f7434420"
+            ),
+            Z: Fp2::ONE,
+        };
+
+        let PB = Point::<Fp2> {
+            X: decode_fp2(
+                "ca88750e54a3167c2a778cb2d02dbcb9b3ce617e306d61c6da2385e50517",
+                "b23bd2393cf7746e443fe8f727bed37e1fd26d51738129fa0943ad160f2d"
+            ),
+            Y: decode_fp2(
+                "4e6204f764d176f69c5be3c073b43c0495c86d5c1dd9cb909acc671d3a23",
+                "5b24e713f71ece6a3f5778cb7eb3d31fba4dbfae06d914e65339a4cb4928"
+            ),
+            Z: Fp2::ONE,
+        };
+
+        let QB = Point::<Fp2> {
+            X: decode_fp2(
+                "637264529c09212772bcc03e55b5cf512f80e00c4b24d998432db4ac4848",
+                "42857cec556b0777f4a6daa2554e01be6900d5b6d7d7b95775238466263e"
+            ),
+            Y: decode_fp2(
+                "d53b250cc535a206f737dba16a29bb1417b166e2589a8dfdd84ffb891f45",
+                "d036af8478a99652a230ba4700d9cb8a8047a3b693d5fa0d18d2c50fc010"
+            ),
+            Z: Fp2::ONE,
+        };
+
+        let P3 = Point::<Fp2> {
+            X: decode_fp2(
+                "db53810117e7bfe64139ae22521d9e1b6f3b8e2f1c39f467c5d43803f207",
+                "6f6fc5872440e6c89a43859944e7e050f8909ccb69c8dee98cd537611429"
+            ),
+            Y: decode_fp2(
+                "6bc75a9ec1727c309ef14e23ca5e64296fa022f18f5d119d53025c068d2c",
+                "07be41c87e42cefe2945987b55707bd0f5577b85ab021a69981c3767e031"
+            ),
+            Z: Fp2::ONE,
+        };
+
+        let Q3 = Point::<Fp2> {
+            X: decode_fp2(
+                "4faf804cebf8e45516ac63fefcf5f274dfd9544699d2c654e1e50e70f30f",
+                "242c02924b6dffef81075bd5374154c3a1a63634a1e6fbbf745d44f3ab18"
+            ),
+            Y: decode_fp2(
+                "88cad573d1bd074e1b2309757959c5812f265faa73a6e36f6704b078df23",
+                "48e6d9bafa0da2fe3b726e71853655db0e2b4c588e889dc91726bd396d2c"
+            ),
+            Z: Fp2::ONE,
+        };
+
+        let psi_p2 = psi_action(&E0, &P2);
+        let psi_q2 = psi_action(&E0, &Q2);
+
+        let eb_e0 = EllipticProduct::new(&EB, &E0);
+
+        let k1 = ProductPoint::new(&PB, &psi_p2);
+        let k2 = ProductPoint::new(&QB, &psi_q2);
+
+        let psi_p3 = psi_action(&E0, &P3);
+        let psi_q3 = psi_action(&E0, &Q3);
+
+        let eval_pts = [
+            ProductPoint::new(&Point::INFINITY, &psi_p3),
+            ProductPoint::new(&Point::INFINITY, &psi_q3),
+        ];
+
+        // Evaluate chain with sqrt strategy
+        let (e_out, images, ok) = eb_e0.elliptic_product_isogeny_sqrt(&k1, &k2, 117, &eval_pts, false);
+        assert_eq!(ok, u32::MAX, "Isogeny chain evaluation failed");
+
+        let (e3, e4) = e_out.curves();
+
+        let j3 = e3.j_invariant();
+        let j_e0 = E0.j_invariant();
+
+        // Identify which curve corresponds to EB_prime in the product structure
+        let (eb_prime, p_idx) = if j3.equals(&j_e0) == u32::MAX {
+            (e4, 1)
+        } else {
+            (e3, 0)
+        };
+
+        let (p3_e3, p3_e4) = images[0].points();
+        let phi_b_p3 = if p_idx == 1 { p3_e4 } else { p3_e3 };
+
+        let (q3_e3, q3_e4) = images[1].points();
+        let phi_b_q3 = if p_idx == 1 { q3_e4 } else { q3_e3 };
+
+        let inv_z_p = phi_b_p3.Z.invert();
+        let p_x = phi_b_p3.X * inv_z_p;
+        let p_y = phi_b_p3.Y * inv_z_p;
+
+        let inv_z_q = phi_b_q3.Z.invert();
+        let q_x = phi_b_q3.X * inv_z_q;
+        let q_y = phi_b_q3.Y * inv_z_q;
+
+        let expected_a_str = "550f146c857d327df9749ef9092ef9310d4d793c4de236e88a6f432c7642bbd0f92b5f64349cd0a9816064c4cdc2dc32f12514ca01e77f982cafb615";
+        let expected_p3_x_str = "f388c4a644b9a217edf4a233d4dbd58b5f017bcccfb72d3c233ee6993911bf01563542b27e2d982e91c347be7f47e8d58f717f33a7b6f45386257848";
+        let expected_p3_y_str = "d3545defd7a6fdd6a3396f8fafd7dddcf0aabe6c96711fb4f3b8deeab8393858e2614104bfdb780c97bc0a57de92058bb54f530f4a655eef9cf59713";
+        let expected_q3_x_str = "0bb4ebc4850f7215b871ef885f1f895500504803405ee3b4059bc7142a31c5ccbb70e3de616360a950ae6aa9ccc70da8bd6926a8bd14bc186c931311";
+        let expected_q3_y_str = "fbae76347b91cd8f45921560c3b9339ae5d88935b0ee335c86411dfd4f23f59d6541dc2423a51241eff2fabe8f53ddbca3a9945e9b458c3f6ee89840";
+
+        let exp_a = decode_fp2_flat(expected_a_str);
+        let exp_p3_x = decode_fp2_flat(expected_p3_x_str);
+        let exp_p3_y = decode_fp2_flat(expected_p3_y_str);
+        let exp_q3_x = decode_fp2_flat(expected_q3_x_str);
+        let exp_q3_y = decode_fp2_flat(expected_q3_y_str);
+
+        assert_eq!(eb_prime.A.equals(&exp_a), u32::MAX, "Codomain A parameter mismatch");
+        assert_eq!(p_x.equals(&exp_p3_x), u32::MAX, "Evaluated P3 X-coordinate mismatch");
+        assert_eq!(p_y.equals(&exp_p3_y), u32::MAX, "Evaluated P3 Y-coordinate mismatch");
+        assert_eq!(q_x.equals(&exp_q3_x), u32::MAX, "Evaluated Q3 X-coordinate mismatch");
+        assert_eq!(q_y.equals(&exp_q3_y), u32::MAX, "Evaluated Q3 Y-coordinate mismatch");
+    }
+}


### PR DESCRIPTION
- In `theta/theta_chain.rs`, add `elliptic_product_isogeny`, that computes a $2^n$ isogeny which assumes points Pi, Qi have order $2^n$ and not $2^{n+2}$ (which does not allow the optimization skipping the square roots)
- rename the previous `elliptic_product_isogeny` which makes use of points of 8-torsion above the kernel into `elliptic_product_isogeny_with_torsion`
- In `theta/theta_isogeny.rs`, add `two_isogeny_4_torsion` and `two_isogeny_2_torsion`, corresponding to SQISign documentation's Algorithm 8.32 and 8.33 respectively